### PR TITLE
Set HTTP client timeout using FACTURAPI_TIMEOUT environment variable

### DIFF
--- a/facturapi/http/client.py
+++ b/facturapi/http/client.py
@@ -9,6 +9,7 @@ from ..types.exc import FacturapiResponseException
 from ..version import CLIENT_VERSION
 
 API_HOST = 'www.facturapi.io/v2'
+FACTURAPI_TIMEOUT = float(os.getenv('FACTURAPI_TIMEOUT', 10.0))
 
 
 class Client:
@@ -31,7 +32,7 @@ class Client:
     client: httpx.Client
 
     def __init__(self) -> None:
-        self.client = httpx.Client()
+        self.client = httpx.Client(timeout=FACTURAPI_TIMEOUT)
         self.client.headers.update(
             {
                 'User-Agent': f'facturapi-python/{CLIENT_VERSION}',

--- a/facturapi/version.py
+++ b/facturapi/version.py
@@ -1,2 +1,2 @@
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 CLIENT_VERSION = __version__


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * HTTP request timeout is now configurable via the `FACTURAPI_TIMEOUT` environment variable (default: 10 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->